### PR TITLE
Fixes metagraph sync

### DIFF
--- a/miners/comfy/miner.py
+++ b/miners/comfy/miner.py
@@ -421,7 +421,7 @@ bt.logging.trace('Miner running. ^C to exit.')
 while True:
     # if subtensor block is different than meta.block by 10, update the miner weight
     if subtensor.block - 10 >= meta.block:
-        meta.sync()
+        meta.sync( subtensor = subtensor )
     if subtensor.block - last_updated_block >= 100:
         bt.logging.trace(f"Setting miner weight")
         # find the uid that matches config.wallet.hotkey [meta.axons[N].hotkey == config.wallet.hotkey]

--- a/validator.py
+++ b/validator.py
@@ -58,7 +58,7 @@ if not os.path.exists(config.validator.save_dir) and config.validator.save_image
 wallet = bt.wallet( config = config )
 sub = bt.subtensor( config = config )
 meta = sub.metagraph( config.netuid )
-meta.sync()
+meta.sync( subtensor = sub )
 dend = bt.dendrite( wallet = wallet )
 
 import torchvision.models as models


### PR DESCRIPTION
Users were having issues using a custom subtensor endpoint

this fix should put an end to that by including subtensor in the .sync() call