### PR TITLE
can't have leading underscore for field names in pydantic v2

### DIFF
--- a/protocol.py
+++ b/protocol.py
@@ -40,12 +40,12 @@ class ImageToImage( TextToImage ):
     required_hash_fields: list[str] = pydantic.Field(  ["text", "negative_prompt", "height", "width", "num_images_per_prompt", "seed", "nsfw_allowed", "image", "similarity"] , allow_mutation = False)
 
 class ValidatorSettings( bt.Synapse ):
-    _version: list[int] = pydantic.Field( [0, 0, 1] , allow_mutation = False)
+    version: list[int] = pydantic.Field( [0, 0, 1] , allow_mutation = False)
     nsfw_allowed: bool
 
 
 class MinerSettings( bt.Synapse ):
-    _version: list[int] = pydantic.Field( [0, 0, 1] , allow_mutation = False)
+    version: list[int] = pydantic.Field( [0, 0, 1] , allow_mutation = False)
     is_public: bool # set to true if you want anyone (non validator) to query your miner
     min_validator_stake: int # minimum stake required to query this miner as a validator
     nsfw_allowed: bool

--- a/validator.py
+++ b/validator.py
@@ -1098,7 +1098,7 @@ def GetImageHashesOfResponses(responses):
     return hashes
 
 async def forward_settings( synapse: ValidatorSettings ) -> ValidatorSettings:
-    synapse._version = __version__
+    synapse.version = __version__
     synapse.nsfw_allowed = config.miner.allow_nsfw
     return synapse
 


### PR DESCRIPTION
In order to have this not cause issues with updating to `pydantic==2.5.2` with latest bittensor release (coming ASAP) need to remove all field names with leading underscores.

Otherwise the code as-is will raise:
`NameError: Fields must not use names with leading underscores; e.g., use 'version' instead of '_version'.`